### PR TITLE
Modify John's references & a fixed typo

### DIFF
--- a/casper-2016.bib
+++ b/casper-2016.bib
@@ -765,7 +765,7 @@ keywords={correlators;microwave antenna arrays;ADC board;AMiBA;Allen deviation;C
 doi={10.1109/URSIGASS.2014.6930032},
 month={Aug},}
 
-TICLE{2016arXiv160607473D,
+@ARTICLE{2016arXiv160607473D,
    author = {{DeBoer}, D.~R. and {Parsons}, A.~R. and {Aguirre}, J.~E. and 
 	{Alexander}, P. and {Ali}, Z.~S. and {Beardsley}, A.~P. and 
 	{Bernardi}, G. and {Bowman}, J.~D. and {Bradley}, R.~F. and 

--- a/casper-2016.tex
+++ b/casper-2016.tex
@@ -441,12 +441,12 @@ are regularly merged into the main library.
 \subsection{CPU/GPU programming/data-transport}
 
 \subsection{Design re-use}
-The \emph{time to science} metric is influenced by the ability to
-reuse designs.  Just as in the world of software reuse, reuse of
-firmware and instrument designs is critical to time-to-science.  The
+The \emph{time-to-science} metric is influenced by the ability to
+reuse designs. Just as in the world of software reuse, reuse of
+firmware and instrument designs is critical to time-to-science. The
 first use of CASPER in a common-user instrument (to my knowledge... -
 JMF) was in the Green Bank Ultimate Pulsar Processing
-Instrument~\cite{duplain2008}, which used the gateware libraries
+Instrument~\cite{guppi}, which used the gateware libraries
 developed by the CASPER group during its inital NSF funded phase.
 These libraries were combined with custom firmware blocks and software
 to form GUPPI, a very successful instrument to this day.  GUPPI was
@@ -465,9 +465,9 @@ effort from the computer system administrators and pulsar scientists.
 
 The next generation of designs to be created in Green Bank from CASPER
 were all based on the ROACH family of configurable signal processors.
-As noted in Table~\ref{tab:xxx}, several ROACH-1 based spectrometers
+As noted in Table~\ref{table:casper-instruments-spectrometers}, several ROACH-1 based spectrometers
 are deployed in Green Bank performing various functions for PI based
-science~\cite{ellingson, ghigo/heatherly,...}.  These all use common
+science~\cite{gbtrans, skynet}.  These all use common
 hardware and firmware, and a great deal of the software for processing
 and analyzing the output is common as well.  None of the PI based
 science would have been feasible without the ease of reuse of the
@@ -476,10 +476,10 @@ ROACH designs.
 In 2013(?), the NSF funded an effort by UC Berkeley in conjunction
 with Green Bank to design the next generation spectrometer for the
 GBT.  The new spectrometer was designed to process the data from the
-small focal plan array receivers being constructed for the GBT, namely
+small focal plane array receivers being constructed for the GBT, namely
 the 7 pixel (dual-pol) K-band receiver, and a 16 pixel (single-pol)
 W-band receiver.  The resulting VEGAS
-spectrometer~\cite{chennamengalam} was built with reused GUPPI
+spectrometer~\cite{chennamangalam2014gpu} was built with reused GUPPI
 software, reused CASPER gateware libraries, and new custom gateware
 blocks that were subsequently added to the CASPER libraries for others
 to use.  Calibration algorithms for the ADCs was gleaned from other


### PR DESCRIPTION
- Modified references in section "Design re-use" to reflect those in the
  bibtex file, with the exception of the \cite{Jack and Rurik} in line
  486
- Fixed typo: added "@AR" infront of "TICLE" in line 768
